### PR TITLE
Rename thenomerter to frontmatter display

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Quick Links:
 ### 🎨 **Dynamic Visual Customization**
 - **JavaScript-powered color rules** - `fm.Priority === 'High' → #ef4444`
 - **Property-based filtering** - show/hide events with complex expressions
-- **Thermometer display** - show extra frontmatter properties inside event chips
+- **Frontmatter Display** - show extra frontmatter properties inside event chips
 - **Multiple view modes** - month, week, day, list with customizable time ranges
 - **Zoom controls** - CTRL+scroll with configurable zoom levels (1-60 minutes)
 

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -108,7 +108,7 @@ fm.Status === 'Done' || fm.Status === 'In Progress'
 Array.isArray(fm.Project) && fm.Project.length > 0
 ```
 
-## Display Properties (Thermometer)
+## Frontmatter Display
 
 Show extra frontmatter properties inside event chips (scrollable when space is tight).
 

--- a/src/components/calendar-view.ts
+++ b/src/components/calendar-view.ts
@@ -364,7 +364,7 @@ export class CalendarView extends MountableView(ItemView) {
 						filePath: event.ref.filePath,
 						folder: event.meta?.folder || "",
 						originalTitle: event.title,
-						thermometerData: event.meta || {},
+						frontmatterDisplayData: event.meta || {},
 						isVirtual: event.isVirtual,
 					},
 					backgroundColor: eventColor,
@@ -428,12 +428,15 @@ export class CalendarView extends MountableView(ItemView) {
 
 		container.appendChild(headerEl);
 
-		if (settings.thermometerProperties.length > 0 && event.extendedProps.thermometerData) {
+		if (
+			settings.frontmatterDisplayProperties.length > 0 &&
+			event.extendedProps.frontmatterDisplayData
+		) {
 			const propsContainer = document.createElement("div");
 			propsContainer.className = "fc-event-props";
 
-			for (const prop of settings.thermometerProperties) {
-				const value = event.extendedProps.thermometerData[prop];
+			for (const prop of settings.frontmatterDisplayProperties) {
+				const value = event.extendedProps.frontmatterDisplayData[prop];
 				if (
 					value !== undefined &&
 					value !== null &&
@@ -492,20 +495,23 @@ export class CalendarView extends MountableView(ItemView) {
 		// Ensure the event color is properly applied
 		const eventColor = this.getEventColor({
 			title: event.title,
-			meta: event.extendedProps.thermometerData,
+			meta: event.extendedProps.frontmatterDisplayData,
 		});
 		element.style.backgroundColor = eventColor;
 		element.style.borderColor = eventColor;
 
-		// Add tooltip with file path and thermometer data
+		// Add tooltip with file path and frontmatter display data
 		const tooltipParts = [`File: ${event.extendedProps.filePath}`];
 
-		// Add thermometer properties to tooltip
+		// Add frontmatter display properties to tooltip
 		const settings = this.bundle.settingsStore.currentSettings;
-		if (settings.thermometerProperties.length > 0 && event.extendedProps.thermometerData) {
-			const thermometerData = event.extendedProps.thermometerData;
-			for (const prop of settings.thermometerProperties) {
-				const value = thermometerData[prop];
+		if (
+			settings.frontmatterDisplayProperties.length > 0 &&
+			event.extendedProps.frontmatterDisplayData
+		) {
+			const displayData = event.extendedProps.frontmatterDisplayData;
+			for (const prop of settings.frontmatterDisplayProperties) {
+				const value = displayData[prop];
 				if (value !== undefined && value !== null && value !== "") {
 					tooltipParts.push(`${prop}: ${value}`);
 				}

--- a/src/components/single-calendar-settings.ts
+++ b/src/components/single-calendar-settings.ts
@@ -106,7 +106,7 @@ export class SingleCalendarSettings {
 
 	private addPropertiesSettings(containerEl: HTMLElement): void {
 		this.addFrontmatterSettings(containerEl);
-		this.addThermometerSettings(containerEl);
+		this.addFrontmatterDisplaySettings(containerEl);
 	}
 
 	private addCalendarSettings(containerEl: HTMLElement): void {
@@ -551,10 +551,10 @@ ${settings.rruleSpecProp}: monday, wednesday, friday
 			});
 	}
 
-	private addThermometerSettings(containerEl: HTMLElement): void {
+	private addFrontmatterDisplaySettings(containerEl: HTMLElement): void {
 		const settings = this.settingsStore.currentSettings;
 
-		containerEl.createEl("h3", { text: "Thermometer Properties" });
+		containerEl.createEl("h3", { text: "Frontmatter Display" });
 
 		const desc = containerEl.createDiv();
 		desc.createEl("p", {
@@ -570,7 +570,7 @@ ${settings.rruleSpecProp}: monday, wednesday, friday
 			.setDesc("Comma-separated list of frontmatter property names to display in events")
 			.addTextArea((text) => {
 				text.setPlaceholder("status, priority, project, tags, category");
-				text.setValue(settings.thermometerProperties.join(", "));
+				text.setValue(settings.frontmatterDisplayProperties.join(", "));
 				text.onChange(async (value) => {
 					const properties = value
 						.split(",")
@@ -578,7 +578,7 @@ ${settings.rruleSpecProp}: monday, wednesday, friday
 						.filter((prop) => prop.length > 0);
 					await this.settingsStore.updateSettings((s) => ({
 						...s,
-						thermometerProperties: properties,
+						frontmatterDisplayProperties: properties,
 					}));
 				});
 				text.inputEl.rows = 3;
@@ -586,7 +586,7 @@ ${settings.rruleSpecProp}: monday, wednesday, friday
 			});
 
 		// Add example display
-		const exampleContainer = containerEl.createDiv("thermometer-example");
+		const exampleContainer = containerEl.createDiv("frontmatter-display-example");
 		exampleContainer.createEl("p", {
 			text: "Example display in calendar:",
 			cls: "setting-item-description",

--- a/src/types/settings-schemas.ts
+++ b/src/types/settings-schemas.ts
@@ -23,7 +23,7 @@ export const PropsSettingsSchema = z.object({
 	rruleProp: z.string().default("RRule"), // property name for RRule type (daily, weekly, etc.)
 	rruleSpecProp: z.string().default("RRuleSpec"), // property name for RRule specification (weekdays, etc.)
 	rruleIdProp: z.string().default("RRuleID"), // property name for recurring event ID
-	thermometerProperties: z.array(z.string()).default([]), // properties to display in calendar nodes
+	frontmatterDisplayProperties: z.array(z.string()).default([]), // frontmatter properties to display inside event chips
 });
 
 export const CalendarSettingsSchema = z.object({

--- a/tests/components/calendar-view.test.ts
+++ b/tests/components/calendar-view.test.ts
@@ -76,7 +76,7 @@ describe.skip("CalendarView", () => {
 			hourStart: 8,
 			hourEnd: 20,
 			hideWeekends: false,
-			thermometerProperties: [],
+			frontmatterDisplayProperties: [],
 			slotDurationMinutes: 10,
 			snapDurationMinutes: 10,
 			zoomLevels: [1, 2, 3, 5, 10, 15, 20, 30, 45, 60],

--- a/tests/core/parser.test.ts
+++ b/tests/core/parser.test.ts
@@ -379,7 +379,7 @@ describe("Parser", () => {
 				folder: "Projects",
 				originalStart: "2024-01-15 10:00",
 				originalEnd: undefined,
-				// All frontmatter properties should be included for thermometer display
+				// All frontmatter properties should be included for Frontmatter Display
 				start: "2024-01-15 10:00",
 				priority: "high",
 				status: "confirmed",


### PR DESCRIPTION
Rename the "Thermometer" feature to "Frontmatter Display" for clearer terminology.

---
<a href="https://cursor.com/background-agent?bcId=bc-39ceea37-e88a-470c-b691-2f178a6b7e95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39ceea37-e88a-470c-b691-2f178a6b7e95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

